### PR TITLE
Add kiosk menu view with category filtering

### DIFF
--- a/src/kiosk.css
+++ b/src/kiosk.css
@@ -18,8 +18,14 @@
 
 .items-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
+}
+
+@media (min-width: 700px) {
+  .items-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .item-card {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,19 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import ReceiptPage from './pages/ReceiptPage'
+import KioskMenuPage from './pages/KioskMenuPage'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/kiosk" element={<KioskMenuPage />} />
+        <Route path="/receipt" element={<ReceiptPage />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/KioskMenuPage.css
+++ b/src/pages/KioskMenuPage.css
@@ -1,0 +1,16 @@
+.category-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.category-tabs button {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
+.category-tabs button.active {
+  background: #222;
+  color: #fff;
+}

--- a/src/pages/KioskMenuPage.tsx
+++ b/src/pages/KioskMenuPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { menu } from '../data/menu';
+import KioskLayout from '../layout/KioskLayout';
+import './KioskMenuPage.css';
+
+const KioskMenuPage = () => {
+  const categories = Array.from(new Set(menu.map((m) => m.category)));
+  const [active, setActive] = useState(categories[0]);
+  return (
+    <KioskLayout>
+      <div className="category-tabs">
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setActive(cat)}
+            className={cat === active ? 'active' : ''}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+      <div className="items-grid">
+        {menu
+          .filter((item) => item.category === active)
+          .map((item) => (
+            <div key={item.id} className="item-card">
+              <div className="item-name">
+                {item.name} - ${item.price.toFixed(2)}
+              </div>
+              <div className="item-desc">{item.description}</div>
+            </div>
+          ))}
+      </div>
+    </KioskLayout>
+  );
+};
+
+export default KioskMenuPage;


### PR DESCRIPTION
## Summary
- create `KioskMenuPage` with category tabs that filter the menu
- add styles for the category tabs
- update `kiosk.css` to use a responsive 2–3 column grid
- enable routing and route `/kiosk` to the new view

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e4163d0e88321b3e3a9cab7dc0f7a